### PR TITLE
fix: fix build with ESPHome 2026.2.x+ (#48)

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -2,6 +2,7 @@ from esphome import automation
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.components import mqtt, uart
+from esphome.components.esp32 import include_builtin_idf_component
 from esphome.const import (
     CONF_ID,
     CONF_TRIGGER_ID,
@@ -84,5 +85,7 @@ async def to_code(config):
     if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("NetworkClientSecure", None)
         cg.add_library("HTTPClient", None)
+    elif CORE.is_esp32:
+        include_builtin_idf_component("esp_http_client")
 
     cg.add_define("USE_NSPANEL_LOVELACE")


### PR DESCRIPTION
Add esp_http_client after it is no longer included by default after esphome/esphome#13610.

Fixes #47